### PR TITLE
添加pixiv搜图多关键词支持;修复p站搜图数量参数问题

### DIFF
--- a/plugins/pixiv_rank_search/__init__.py
+++ b/plugins/pixiv_rank_search/__init__.py
@@ -44,6 +44,8 @@ usage：
             搜图 樱岛麻衣
             搜图 樱岛麻衣 5
             搜图 樱岛麻衣 5 r18
+            搜图 樱岛麻衣#1000users 5
+        【多个关键词用#分割】
         【默认为 热度排序】
         【注意空格！！】【在线搜索会较慢】【数量可能不符？可能该页数量不够，也可能被R-18屏蔽】
 """.strip()
@@ -161,8 +163,8 @@ async def _(bot: Bot, event: MessageEvent, arg: Message = CommandArg()):
     info_list = None
     num = 10
     page = 1
-    if (n := len(msg)) == 1:
-        keyword = msg[0]
+    if (n := len(msg)) >= 1:
+        keyword = msg[0].replace("#"," ")
     if n > 1:
         if not is_number(msg[1]):
             await pixiv_keyword.finish("图片数量必须是数字！", at_sender=True)

--- a/plugins/pixiv_rank_search/__init__.py
+++ b/plugins/pixiv_rank_search/__init__.py
@@ -163,7 +163,7 @@ async def _(bot: Bot, event: MessageEvent, arg: Message = CommandArg()):
     info_list = None
     num = 10
     page = 1
-    if (n := len(msg)) >= 1:
+    if (n := len(msg)) > 0:
         keyword = msg[0].replace("#"," ")
     if n > 1:
         if not is_number(msg[1]):


### PR DESCRIPTION
您好,真寻非常可爱.
我发现[api.obfs.dev](https://api.obfs.dev)的pixiv接口是可以查询多个关键词的(通过空格分割), 我们可以用#来接受多个关键词
然后海豹运算符这里是不是有个bug呀,提供多个参数的时候keyword会一直为None吧