### PR TITLE
修复有置顶的up主B站动态获取失败

### DIFF
--- a/plugins/bilibili_sub/data_source.py
+++ b/plugins/bilibili_sub/data_source.py
@@ -330,7 +330,7 @@ async def get_user_dynamic(
                     """
                     xs = document.getElementsByClassName('bili-dyn-item__tag');
                     for (x of xs) {
-                      x.parentNode.remove();
+                      x.parentNode.parentNode.remove();
                     }
                 """
                 )


### PR DESCRIPTION
bili-dyn-item__tag的父项的父项才是完整的一条置顶动态
![Q{}M}DB7BY)GV6VF9`D3`II](https://user-images.githubusercontent.com/30636113/169746797-166f8835-298e-410f-9dbe-9e7d4bfac3dd.png)

