### PR TITLE
修复复读不能复读图片的问题

### DIFF
--- a/plugins/fudu.py
+++ b/plugins/fudu.py
@@ -1,5 +1,5 @@
 from nonebot.adapters.onebot.v11.permission import GROUP
-from configs.path_config import TEMP_PATH
+from configs.path_config import IMAGE_PATH
 from utils.image_utils import get_img_hash
 import random
 from utils.message_builder import image
@@ -106,7 +106,10 @@ async def _(event: GroupMessageEvent):
             "fudu", "FUDU_PROBABILITY"
         ) and not _fudu_list.is_repeater(event.group_id):
             if random.random() < 0.2:
-                await fudu.finish("[[_task|fudu]]打断施法！")
+                if msg.endswith("打断施法！"):
+                    await fudu.finish("[[_task|fudu]]打断" + msg)        
+                else:
+                    await fudu.finish("[[_task|fudu]]打断施法！")
             _fudu_list.set_repeater(event.group_id)
             if img and msg:
                 rst = msg + image(f"compare_{event.group_id}_img.jpg", "temp")
@@ -117,17 +120,15 @@ async def _(event: GroupMessageEvent):
             else:
                 rst = ""
             if rst:
-                if rst.endswith("打断施法！"):
-                    rst = "打断" + rst
-                await fudu.send("[[_task|fudu]]" + rst)
+                await fudu.finish("[[_task|fudu]]" + rst)
 
 
 async def get_fudu_img_hash(url, group_id):
     try:
         if await AsyncHttpx.download_file(
-            url, TEMP_PATH / f"compare_{group_id}_img.jpg"
+            url, IMAGE_PATH / "temp" / f"compare_{group_id}_img.jpg"
         ):
-            img_hash = get_img_hash(TEMP_PATH / f"compare_{group_id}_img.jpg")
+            img_hash = get_img_hash(IMAGE_PATH / "temp" / f"compare_{group_id}_img.jpg")
             return str(img_hash)
         else:
             logger.warning(f"复读下载图片失败...")

--- a/plugins/fudu.py
+++ b/plugins/fudu.py
@@ -1,5 +1,5 @@
 from nonebot.adapters.onebot.v11.permission import GROUP
-from configs.path_config import IMAGE_PATH
+from configs.path_config import TEMP_PATH
 from utils.image_utils import get_img_hash
 import random
 from utils.message_builder import image
@@ -112,9 +112,9 @@ async def _(event: GroupMessageEvent):
                     await fudu.finish("[[_task|fudu]]打断施法！")
             _fudu_list.set_repeater(event.group_id)
             if img and msg:
-                rst = msg + image(f"compare_{event.group_id}_img.jpg", "temp")
+                rst = msg + image(TEMP_PATH / f"compare_{event.group_id}_img.jpg")
             elif img:
-                rst = image(f"compare_{event.group_id}_img.jpg", "temp")
+                rst = image(TEMP_PATH / f"compare_{event.group_id}_img.jpg")
             elif msg:
                 rst = msg
             else:
@@ -126,9 +126,9 @@ async def _(event: GroupMessageEvent):
 async def get_fudu_img_hash(url, group_id):
     try:
         if await AsyncHttpx.download_file(
-            url, IMAGE_PATH / "temp" / f"compare_{group_id}_img.jpg"
+            url, TEMP_PATH / f"compare_{group_id}_img.jpg"
         ):
-            img_hash = get_img_hash(IMAGE_PATH / "temp" / f"compare_{group_id}_img.jpg")
+            img_hash = get_img_hash(TEMP_PATH / f"compare_{group_id}_img.jpg")
             return str(img_hash)
         else:
             logger.warning(f"复读下载图片失败...")


### PR DESCRIPTION
IMAGE_PATH = Path() / "resources" / "image"
TEMP_PATH = Path() / "resources" / "temp"
`image()`默认读取在` resource/img `目录下，读写路径不同，导致找不到图片
`image(f"compare_{event.group_id}_img.jpg", "temp")`读取的是`resources/image/temp`下的图片


打断打断施法！，rst.endswith("打断施法！")在复读内容含有图片时会报错