### PR TITLE
修改翻译插件，添加缺失的冒号

### DIFF
--- a/plugins/translate/data_source.py
+++ b/plugins/translate/data_source.py
@@ -16,7 +16,7 @@ async def translate_msg(language_type, msg):
     }
     data = (await AsyncHttpx.post(url, data=data)).json()
     if data["errorCode"] == 0:
-        return f'原文：{msg}\n翻译{data["translateResult"][0][0]["tgt"]}'
+        return f'原文：{msg}\n翻译：{data["translateResult"][0][0]["tgt"]}'
     return "翻译惜败.."
 
 


### PR DESCRIPTION
只是一个小小的问题。

发送的消息中，“原文：” 是正常的，“翻译” 缺少冒号，导致与译文贴贴。