### PR TITLE
定时消息插件apscheduler中的早安发送格式修正

### DIFF
--- a/basic_plugins/apscheduler/__init__.py
+++ b/basic_plugins/apscheduler/__init__.py
@@ -59,7 +59,7 @@ async def _():
         for g in gl:
             result = image("zao.jpg", "zhenxun")
             try:
-                await bot.send_group_msg(group_id=g, message="[[_task|zwa]]早上好" + result)
+                await bot.send_group_msg(group_id=g, message=f"[[_task|zwa]]早上好" + result)
             except ActionFailed:
                 logger.warning(f"{g} 群被禁言中，无法发送早安")
     except Exception as e:


### PR DESCRIPTION
之前每天23:59都能正常发送晚安消息，但早上6:01没有早安消息

zhenxun_bot中的日志该插件是正常工作的，但看go-cqhttp中显示群消息发送失败：账号可能被风控；但一般群消息是能发出去的

在__init__.py中对比一下晚安与早安的代码后，发现早安的发送消息前面少了f，也就是format函数，加上去后和晚安格式一样，然后今天就能正常发送早安消息了

（其他一些消息提示风控的原因有没有可能也是少了格式化输出呢）