### PR TITLE
修复微博热搜报错,发红包小bug

### DIFF
--- a/plugins/gold_redbag/data_source.py
+++ b/plugins/gold_redbag/data_source.py
@@ -64,8 +64,8 @@ async def _generate_open_redbag_pic(user_id: int, send_user_nickname: str, amoun
     head = BuildImage(1000, 980, font_size=30, background=f'{IMAGE_PATH}/prts/redbag_12.png')
     size = BuildImage(0, 0, font_size=50).getsize(send_user_nickname)
     # QQ头像
-    ava_bk = BuildImage(100 + size[0], 66, color='white', font_size=50)
-    ava = BuildImage(66, 66, background=BytesIO(await get_user_avatar(user_id)))
+    ava_bk = BuildImage(100 + size[0], 66, is_alpha=True, font_size=50)
+    ava = BuildImage(66, 66, is_alpha=True, background=BytesIO(await get_user_avatar(user_id)))
     ava_bk.paste(ava)
     ava_bk.text((100, 7), send_user_nickname)
     # ava_bk.show()
@@ -73,7 +73,7 @@ async def _generate_open_redbag_pic(user_id: int, send_user_nickname: str, amoun
     head.paste(ava_bk, (int((1000 - ava_bk_w) / 2), 300))
     # 金额
     size = BuildImage(0, 0, font_size=150).getsize(amount)
-    price = BuildImage(size[0], size[1], font_size=150)
+    price = BuildImage(size[0], size[1], is_alpha=True, font_size=150)
     price.text((0, 0), amount, fill=(209, 171, 108))
     # 金币中文
     head.paste(price, (int((1000 - size[0]) / 2) - 50, 460))

--- a/plugins/wbtop/data_source.py
+++ b/plugins/wbtop/data_source.py
@@ -52,7 +52,7 @@ def gen_wbtop_pic(data: dict) -> MessageSegment:
     text_bk = BuildImage(700, 32 * 50, 700, 32, color="#797979")
     for i, data in enumerate(data):
         title = f"{i + 1}. {data['hot_word']}"
-        hot = data["hot_word_num"]
+        hot = str(data["hot_word_num"])
         img = BuildImage(700, 30, font_size=20)
         w, h = img.getsize(title)
         img.text((10, int((30 - h) / 2)), title)


### PR DESCRIPTION
**微博热搜问题**:报错int类型不能迭代,于是将hot对象先转为str即可.此问题已在issues里面被提及.
**发红包问题**:当添加背景不是白色的红包封面时,发现"收到的金额"以及"用户名"的背景都是白色,很影响观感,查看BuildImage类后,发现只要先创建透明背景,并且在paste时添加参数(此参数默认关闭)即可解决.
**发红包问题解决前:注意看小真寻的红包以及76的背景是白色的**
![166a01a9593d3efc](https://user-images.githubusercontent.com/105900675/170806866-b076296f-5d44-413f-9fb2-e1936e41f765.png)
**发红包问题解决后:**
![-e7c549dd3d53d00](https://user-images.githubusercontent.com/105900675/170806891-3a42ec64-7a6f-48b3-a203-e4dbfd04f081.png)

