### PR TITLE
修复原神树脂仅在满时才提示的小bug

### DIFF
--- a/plugins/genshin/query_user/resin_remind/init_task.py
+++ b/plugins/genshin/query_user/resin_remind/init_task.py
@@ -144,8 +144,8 @@ async def _remind(user_id: int, uid: str):
     now = datetime.now(pytz.timezone("Asia/Shanghai"))
     next_time = None
     if code == 200:
-        current_resin = data["current_resin"]  # 当前树脂
-        max_resin = data["max_resin"]  # 最大树脂
+        current_resin = int(data["current_resin"])  # 当前树脂
+        max_resin = int(data["max_resin"])  # 最大树脂
         msg = f"你的已经存了 {current_resin} 个树脂了！不要忘记刷掉！"
         # resin_recovery_time = data["resin_recovery_time"]  # 树脂全部回复时间
         if current_resin < max_resin:


### PR DESCRIPTION
**问题发现:**每次提示都是在160,并未有说明文档中描述的从120开始.
**问题解决:**在源码中发现进行字符串类型比较时可能出现问题:例如print('40'<'120')打印的结果是false,导致无法触发后续判断.所以将源代码中的string类型转换成int类型即可解决问题.