### PR TITLE
fix image_utils.py

### DIFF
--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -178,7 +178,7 @@ class BuildImage:
         self.paste_image_height = int(paste_image_height)
         self.current_w = 0
         self.current_h = 0
-        self.font = ImageFont.truetype(str(FONT_PATH / font), font_size)
+        self.font = ImageFont.truetype(str(FONT_PATH / font), int(font_size))
         if not plain_text and not color:
             color = (255, 255, 255)
         self.background = background


### PR DESCRIPTION
https://github.com/HibiKier/zhenxun_bot/commit/ae8a214a3a5c08a51cacd1dc37583c0b32e6332f
之前这个commit里面看到函数参数有写着int类型就把`font_size`类型转换给去了，结果导致了部分地方输入float类型后报错。现在改回来