### PR TITLE
原神黄历增加重试次数

### DIFF
--- a/plugins/genshin/almanac/data_source.py
+++ b/plugins/genshin/almanac/data_source.py
@@ -5,6 +5,8 @@ from utils.http_utils import AsyncPlaywright
 from nonebot.adapters.onebot.v11 import MessageSegment
 from typing import Optional
 import os
+from services.log import logger
+
 
 url = "https://genshin.pub"
 
@@ -21,6 +23,15 @@ async def get_alc_image(path: Path) -> Optional[MessageSegment]:
             file.unlink()
     if f"{date}.png" in os.listdir(path):
         return image(f"{date}.png", "genshin/alc")
-    return await AsyncPlaywright.screenshot(
-        url, path / f"{date}.png", ".GSAlmanacs_gs_almanacs__3qT_A"
-    )
+    alc_image = None
+    i = 1
+    max_try = 20
+    while i <= max_try:
+        alc_image =  await AsyncPlaywright.screenshot(
+            url, path / f"{date}.png", ".GSAlmanacs_gs_almanacs__3qT_A"
+        )
+        if alc_image:
+            return alc_image
+        logger.info(f'第{i}次尝试获取黄历失败,剩余{max_try - i}次...')
+        i += 1
+    return alc_image


### PR DESCRIPTION
### 问题发现
原神黄历有时不能正常推送
### 问题探索
原网站`https://genshin.pub`有时无响应,甚至用个人电脑有时也会出现这种问题,怀疑是网站自身问题
### 问题解决
添加循坏,尝试重新访问

> 效果如下(测试中已将`max_try`调为了50):
![Screenshot 2022-06-13 092421](https://user-images.githubusercontent.com/105900675/173264264-90e881e5-1113-48f1-af7a-f1ac0abccd80.jpg)
![Screenshot 2022-06-13 092519](https://user-images.githubusercontent.com/105900675/173264271-beaec10b-b9b6-4a46-bb75-09e29f15c081.jpg)

> 在尝试7次,总用时10分钟后推送成功:
![Screenshot_20220613_093718_com tencent mobileqq_e](https://user-images.githubusercontent.com/105900675/173264486-0ec7a0af-3696-452a-9bfc-ee7496f6cd48.jpg)

