### PR TITLE
fix: 自动更新群组

### DIFF
--- a/basic_plugins/apscheduler/__init__.py
+++ b/basic_plugins/apscheduler/__init__.py
@@ -107,6 +107,7 @@ async def _():
                 group_info["group_name"],
                 group_info["max_member_count"],
                 group_info["member_count"],
+                1
             )
             logger.info(f"自动更新群组 {g} 信息成功")
     except Exception as e:


### PR DESCRIPTION
group_flag不能为null，因此当自动添加新群组时，会出错。
于是参考如下代码把group_flag设为了1
https://github.com/HibiKier/zhenxun_bot/blob/0736533389f0d773ecaf08c3ec4fc099b5a02597/basic_plugins/super_cmd/update_friend_group_info.py#L43-L49
