### PR TITLE
修复wordbank的一些小问题

### DIFF
--- a/plugins/word_bank/_rule.py
+++ b/plugins/word_bank/_rule.py
@@ -12,7 +12,7 @@ async def check(bot: Bot, event: Event, state: T_State) -> bool:
         list_img = get_message_img_file(event.json())
         if list_img:
             for img_file in list_img:
-                strinfo = re.compile(f"{img_file},subType=\d*]")
+                strinfo = re.compile(f"{img_file},.*?]")
                 msg = strinfo.sub(f'{img_file}]', msg)
         return bool(
             await WordBank.check(event.group_id, msg, event.is_tome())

--- a/plugins/word_bank/message_handle.py
+++ b/plugins/word_bank/message_handle.py
@@ -23,7 +23,7 @@ async def _(event: GroupMessageEvent):
     list_img = get_message_img_file(event.json())
     if list_img:
         for img_file in list_img:
-            strinfo = re.compile(f"{img_file},subType=\d*]")
+            strinfo = re.compile(f"{img_file},.*?]")
             msg = strinfo.sub(f'{img_file}]', msg)
     q = await WordBank.check(
         event.group_id, msg, event.is_tome()

--- a/plugins/word_bank/word_hanlde.py
+++ b/plugins/word_bank/word_hanlde.py
@@ -293,7 +293,7 @@ async def get__builder(event, _problem, answer, idx):
                 if f"__placeholder_{rand}_{idx}.jpg" not in os.listdir(data_dir / f"{event.group_id}"):
                     break
                 rand = random.randint(1, 10000) + random.randint(1, 114514)
-            strinfo = re.compile(f"\[CQ:image,file={r.group(1)},.*url={_x_list[0]}\?{_x_list[1]}.*\]")
+            strinfo = re.compile(f"\[CQ:image,file={r.group(1)},.*url={_x_list[0]}\?{_x_list[1]}.*?]")
             answer = strinfo.sub(f"[__placeholder_{idx}]", answer)
             await AsyncHttpx.download_file(
                 img, data_dir / f"{event.group_id}" / f"__placeholder_{rand}_{idx}.jpg"

--- a/plugins/word_bank/word_hanlde.py
+++ b/plugins/word_bank/word_hanlde.py
@@ -300,9 +300,9 @@ async def get__builder(event, _problem, answer, idx):
             )
             _builder.set_placeholder(idx, f"__placeholder_{rand}_{idx}.jpg")
             idx += 1
-        r_problem = re.search(rf"\[CQ:image,file=(.*?),url={_x}.*?]", _p)
+        r_problem = re.search(rf"\[CQ:image,file=(.*?)(,subType=\d)?,url={_x}.*?]", _p)
         if r_problem:
-            strinfo = re.compile(f",url={_x_list[0]}\?{_x_list[1]},subType=\d*?]")
+            strinfo = re.compile(f"(,subType=\d)?,url={_x_list[0]}\?{_x_list[1]}.*?]")
             _problem = strinfo.sub(f"]", _problem)
             _p = strinfo.sub(f"]", _p)
             problem += _p[: _p.find(f"[CQ:image,file={r_problem.group(1)}]")] + image(img)


### PR DESCRIPTION
1. 修复https://github.com/HibiKier/zhenxun_bot/commit/e9e9f81bdb1a20ae26cd6a87f8146ddb0ef716a9 少加了个`?`导致answer为多个连续图片时无法正确处理。
2. 修复`go-cqhttp v1.0.0-rc2`下problem为图片时无法被正确处理的问题。

目前使用了`go-cqhttp v1.0.0-rc2`和`go-cqhttp v1.0.0-rc1`测试暂未发现问题