### PR TITLE
修复原神树脂重复提醒的bug

### DIFF
--- a/plugins/genshin/query_user/resin_remind/init_task.py
+++ b/plugins/genshin/query_user/resin_remind/init_task.py
@@ -149,12 +149,12 @@ async def _remind(user_id: int, uid: str):
         if current_resin < max_resin:
             user_manager.remove(uid)
             user_manager.remove_overflow(uid)
-        if current_resin <= max_resin - 40:
-            next_time = now + timedelta(minutes=(max_resin - 40 - current_resin + 1) * 8, seconds=10)
-        elif max_resin - 40 < current_resin <= max_resin - 20:
-            next_time = now + timedelta(minutes=(max_resin - 20 - current_resin + 1) * 8, seconds=10)
-        elif max_resin - 20 < current_resin < max_resin:
-            next_time = now + timedelta(minutes=(max_resin - current_resin) * 8, seconds=10)
+        if current_resin < max_resin - 40:
+            next_time = now + timedelta(minutes=(max_resin - 40 - current_resin) * 8)
+        elif max_resin - 40 <= current_resin < max_resin - 20:
+            next_time = now + timedelta(minutes=(max_resin - 20 - current_resin) * 8)
+        elif max_resin - 20 <= current_resin < max_resin:
+            next_time = now + timedelta(minutes=(max_resin - current_resin) * 8)
         elif current_resin == max_resin:
             custom_overflow_resin = Config.get_config("resin_remind", "CUSTOM_RESIN_OVERFLOW_REMIND")
             if user_manager.is_overflow(uid) and custom_overflow_resin:


### PR DESCRIPTION
### 问题发现
当树脂达到120时,有时会被提醒2次
### 问题分析
当树脂达到120时,首先会被判断`<= max_resin - 40`,于是设置下一个schedule在`8min10s`之后,导致再次被提醒.这种情况应该只会出现在重启机器人时刚好获取了某用户为120树脂的情况
### 问题解决
修改判断中`＝`的条件,并去除`8min10s`的增加时间