### PR TITLE
更改更新重启指令权重

### DIFF
--- a/plugins/check_zhenxun_update/__init__.py
+++ b/plugins/check_zhenxun_update/__init__.py
@@ -37,14 +37,14 @@ __plugin_configs__ = {
     }
 }
 
-update_zhenxun = on_command("检查更新真寻", permission=SUPERUSER, priority=1, block=True)
+update_zhenxun = on_command("检查更新真寻", permission=SUPERUSER, priority=9, block=True)
 
 restart = on_command(
     "重启",
     aliases={"restart"},
     permission=SUPERUSER,
     rule=to_me(),
-    priority=1,
+    priority=9,
     block=True,
 )
 

--- a/plugins/check_zhenxun_update/data_source.py
+++ b/plugins/check_zhenxun_update/data_source.py
@@ -42,7 +42,7 @@ async def remind(bot: Bot):
                     "pid=${pid%/*}\n"
                     "kill -9 $pid\n"
                     "sleep 3\n"
-                    "python3 bot.py"
+                    "python3.9 bot.py"
                 )
             os.system("chmod +x ./restart.sh")
             logger.info("已自动生成 restart.sh(重启) 文件，请检查脚本是否与本地指令符合...")


### PR DESCRIPTION
更新权重过低以至于被其他指令覆盖，无法正常使用此功能。同时不添加tome以使版本信息仅私聊，保证只有超级用户知道版本信息
重启指令目前没有被覆盖，但是为了以后考虑还是提高了权重

把重启命令里的py加上了py3.9以适配一键安装脚本的版本，某些系统包centos默认的py3是py3.4

其实小问题自己改一下无所谓，但是我更新了之后重写被覆盖了，还是pr到GitHub，以后更新不用再写一遍了