### PR TITLE
对__plugin_settings__缺省的情况做些处理

### DIFF
--- a/basic_plugins/init_plugin_config/init_plugins_settings.py
+++ b/basic_plugins/init_plugin_config/init_plugins_settings.py
@@ -80,15 +80,6 @@ def init_plugins_settings(data_path: str):
                             plugin_settings["cmd"] = []
                         if plugin_name not in plugin_settings["cmd"]:
                             plugin_settings["cmd"].append(plugin_name)
-                        try:
-                            plugin_cmd = _module.__getattribute__(
-                                "__plugin_cmd__"
-                            )
-                        except AttributeError:
-                            plugin_cmd = []
-                        for cmd in plugin_cmd:
-                            if cmd not in plugin_settings["cmd"]:
-                                plugin_settings["cmd"].append(cmd)
                         if plugins2settings_manager.get(
                             matcher.plugin_name
                         ) and plugins2settings_manager[matcher.plugin_name].get(

--- a/basic_plugins/init_plugin_config/init_plugins_settings.py
+++ b/basic_plugins/init_plugin_config/init_plugins_settings.py
@@ -68,16 +68,27 @@ def init_plugins_settings(data_path: str):
                 else:
                     try:
                         _tmp_module[matcher.plugin_name] = plugin_name
-                        plugin_settings = _module.__getattribute__(
-                            "__plugin_settings__"
-                        )
+                        try:
+                            plugin_settings = _module.__getattribute__(
+                                "__plugin_settings__"
+                            )
+                        except AttributeError:
+                            plugin_settings = {}
                         if plugin_settings.get('cost_gold') is None:
                             plugin_settings['cost_gold'] = 0
-                        if (
-                            plugin_settings.get("cmd") is not None
-                            and plugin_name not in plugin_settings["cmd"]
-                        ):
+                        if "cmd" not in plugin_settings:
+                            plugin_settings["cmd"] = []
+                        if plugin_name not in plugin_settings["cmd"]:
                             plugin_settings["cmd"].append(plugin_name)
+                        try:
+                            plugin_cmd = _module.__getattribute__(
+                                "__plugin_cmd__"
+                            )
+                        except AttributeError:
+                            plugin_cmd = []
+                        for cmd in plugin_cmd:
+                            if cmd not in plugin_settings["cmd"]:
+                                plugin_settings["cmd"].append(cmd)
                         if plugins2settings_manager.get(
                             matcher.plugin_name
                         ) and plugins2settings_manager[matcher.plugin_name].get(


### PR DESCRIPTION
1. 修复当没写`__plugin_settings__`时无法正常生成`plugin2settings`（虽然有要求插件具备__plugin_settings__属性，但大多数情况下默认值够用就直接不写了，然而之前不写会导致plugin2settings中没有该插件的信息）