### PR TITLE
修复色图插件最近加tag参数后搜不到图的问题

### DIFF
--- a/plugins/send_setu_/send_setu/data_source.py
+++ b/plugins/send_setu_/send_setu/data_source.py
@@ -32,7 +32,7 @@ async def get_setu_urls(
     params = {
         "r18": r18,  # 添加r18参数 0为否，1为是，2为混合
         "tag": tags,  # 若指定tag
-        "num": 100,  # 一次返回的结果数量
+        "num": 20,  # 一次返回的结果数量
         "size": ["original"],
     }
     for count in range(3):


### PR DESCRIPTION
插件所用API更新，最大数量num改为20
https://api.lolicon.app/#/setu
![image](https://user-images.githubusercontent.com/105792144/176171657-77e9c53b-b5ab-4131-917d-14a07ae296dd.png)