### PR TITLE
修复一个导致启动报错的BUG

### DIFF
--- a/utils/manager/plugins2settings_manager.py
+++ b/utils/manager/plugins2settings_manager.py
@@ -37,6 +37,7 @@ class Plugins2settingsManager(StaticData):
         limit_superuser: Optional[bool] = False,
         plugin_type: Tuple[Union[str, int]] = ("normal",),
         cost_gold: int = 0,
+        **kwargs
     ):
         """
         添加一个插件设置


### PR DESCRIPTION
![M0G 4_7WKU0AL8WC}39@BPY](https://user-images.githubusercontent.com/45615222/185985513-fc3c9336-d043-4e9e-a8ba-5416846b3de9.png)


试了几次，在建立配置文件的时候，如果缺少7月31号删除的这句代码，那么会出现如图报错；
加回去就正常了。