### PR TITLE
优化了music插件中@music_handler命令后未跟参数而产生的一个bug

### DIFF
--- a/plugins/music/__init__.py
+++ b/plugins/music/__init__.py
@@ -1,7 +1,7 @@
 from .music_163 import get_song_id, get_song_info
 from nonebot.adapters.onebot.v11 import Bot, MessageEvent, GroupMessageEvent, Message
-from nonebot.params import CommandArg
-from nonebot.typing import T_State
+from nonebot.params import CommandArg,Arg
+from nonebot.matcher import Matcher
 from services.log import logger
 from nonebot import on_command
 from utils.message_builder import music
@@ -31,14 +31,15 @@ music_handler = on_command("点歌", priority=5, block=True)
 
 
 @music_handler.handle()
-async def handle_first_receive(state: T_State, arg: Message = CommandArg()):
-    if args := arg.extract_plain_text().strip():
-        state["song_name"] = args
-
-
+async def handle_first_receive(matcher: Matcher, args: Message = CommandArg()):
+    #/Edited by U2yyy/使用matcher来set key值
+    if args:
+        matcher.set_arg("song_name",args)
+        
 @music_handler.got("song_name", prompt="歌名是？")
-async def _(bot: Bot, event: MessageEvent, state: T_State):
-    song = state["song_name"]
+async def _(bot: Bot, event: MessageEvent, song_name: Message = Arg()):
+    #/Edited by U2yyy/这里把set或者传入的key值转换为string类型值来供函数使用
+    song = song_name.extract_plain_text().strip()
     song_id = await get_song_id(song)
     if not song_id:
         await music_handler.finish("没有找到这首歌！", at_sender=True)
@@ -48,7 +49,3 @@ async def _(bot: Bot, event: MessageEvent, state: T_State):
         f"{event.group_id if isinstance(event, GroupMessageEvent) else 'private'})"
         f" 点歌 :{song}"
     )
-
-
-
-


### PR DESCRIPTION
当未接收到参数时，后传入的参数并未被@music_handler.got()接受，因此也就没有效果产生。用Nonebot提供的Matcher即能在接收到参数时set key值，未接收到参数时@music_handler.got()进行传入参数并接受的操作，从而实现一个对话流。具体修改在代码中有注释。
