### PR TITLE
fix get_video()

### DIFF
--- a/plugins/bilibili_sub/utils.py
+++ b/plugins/bilibili_sub/utils.py
@@ -106,7 +106,7 @@ async def get_videos(
     headers["Referer"] = f"https://space.bilibili.com/{uid}/video"
     async with AsyncClient() as client:
         r = await client.head(
-            "https://space.bilibili.com",
+            "https://www.bilibili.com",
             headers=headers,
         )
         params = {


### PR DESCRIPTION
space.bilibili.com不会set cookie了似乎，改成www.bilibili.com

测试100次内调用get_video请求成功数
bilireq0.2.2post0：61/100
改后的本代码: 100/100

所以等https://github.com/HibiKier/zhenxun_bot/pull/1112 这个pr被吃了后还要把这改回来![image](https://user-images.githubusercontent.com/13503375/191653917-4f5a70cb-540f-4db3-a088-5ca4db12b048.png)