### PR TITLE
:bug: Fix a bug in open_cases to get vanilla knives' prices

### DIFF
--- a/plugins/open_cases/utils.py
+++ b/plugins/open_cases/utils.py
@@ -73,7 +73,7 @@ async def util_get_buff_price(case_name: str = "狂牙大行动") -> str:
                                     "page_num": f"{i}",
                                     "search": skin,
                                 }
-                                res = await AsyncHttpx.get(url, params=parameter)
+                                res = await AsyncHttpx.get(url, params=parameter, cookies=cookie)
                                 data = res.json()["data"][
                                     "items"
                                 ]


### PR DESCRIPTION
修复一个可能存在的 BUG（好像很久了但是我没见有人反馈过？可能是我系统的问题？）

在 `更新开箱价格` 的时候，对于原版刀判断时 httpx 请求没有包括 cookie，导致 `res` 请求的结果为 `{code: "login required"}` 进而导致 `data` 出错

