### PR TITLE
修复epic报错，优化简介

### DIFF
--- a/plugins/epic/data_source.py
+++ b/plugins/epic/data_source.py
@@ -112,9 +112,15 @@ async def get_epic_free(bot: Bot, type_event: str):
                         if pair["key"] == "publisherName":
                             game_pub = pair["value"]
                     if game.get("productSlug"):
-                    	gamesDesp = await get_epic_game_desp(game["productSlug"])
-                    	#game_desp = game["description"]
-                    	game_desp = gamesDesp["description"]
+                        gamesDesp = await get_epic_game_desp(game["productSlug"])
+                        try:
+                            #是否存在简短的介绍
+                            if "shortDescription" in gamesDesp:
+                                game_desp = gamesDesp["shortDescription"]
+                        except KeyError:
+                                game_desp = gamesDesp["description"]
+                    else:
+                        game_desp = game["description"]
                     try:
                         end_date_iso = game["promotions"]["promotionalOffers"][0][
                             "promotionalOffers"


### PR DESCRIPTION
1.修复了因报错UnboundLocalError: local variable 'game_desp' referenced before assignment而导致的发送失败
2.修复因简介过长导致的win版QQ在群聊中无法查看发送的合并转发消息的问题（疑似因为单条消息过长？测试时安卓QQ无此异常）（当存在简短介绍时，使用简短介绍）