### PR TITLE
修复B站转发卡片BUG

### DIFF
--- a/plugins/parse_bilibili_json.py
+++ b/plugins/parse_bilibili_json.py
@@ -55,7 +55,7 @@ async def _(event: GroupMessageEvent):
             data = None
         if data:
             # 转发视频
-            if data.get("desc") == "哔哩哔哩":
+            if data.get("desc") == "哔哩哔哩" or data.get('prompt').find('哔哩哔哩') != -1:
                 async with aiohttp.ClientSession(
                     headers=get_user_agent()
                 ) as session:
@@ -64,6 +64,8 @@ async def _(event: GroupMessageEvent):
                             timeout=7,
                     ) as response:
                         url = str(response.url).split("?")[0]
+                        if url[-1] == '/':
+                            url = url[:-1]
                         bvid = url.split("/")[-1]
                         vd_info = await video.get_video_base_info(bvid)
             # 转发专栏


### PR DESCRIPTION
1. 最新URL `https://b23.tv/nz4tMtX` 返回
```
HTTP/2 301 
date: Tue, 31 Jan 2023 09:43:07 GMT
content-type: text/html; charset=utf-8
content-length: 781
set-cookie: ******; path=/; expires=Mon, 27 Oct 2025 09:43:07 GMT; domain=.bilibili.com
set-cookie: b_nut=1675158187; path=/; expires=Wed, 31 Jan 2024 09:43:07 GMT; domain=.bilibili.com
location: /video/BV1CM4y197A4/?buvid=******
vary: Origin,Accept-Encoding
idc: shjd
x-cache-webcdn: BYPASS from blzone07
```

这时候 url 会变成 `/video/BV1CM4y197A4/` 需要去除末尾的/来提取BVID

2. 某些转发（比如ios客户端）目前QQ小程序的desc为空，需要在prompt里检测
```json
[CQ:json,data={"app":"com.tencent.miniapp_01"&#44;"appID":"100951776"&#44;"bthirdappforward":true&#44;"bthirdappforwardforbackendswitch":true&#44;"config":{"autoSize":0&#44;"ctime":1675159871&#44;"forward":1&#44;"height":0&#44;"token":"d1dda06f69b12d511972e87ec49b2a19"&#44;"type":"normal"&#44;"width":0}&#44;"desc":""&#44;"extra":{"app_type":1&#44;"appid":100951776&#44;"uin":28696786}&#44;"meta":{"detail_1":{"appType":0&#44;"appid":"1109937557"&#44;"desc":"网络中挖到国防光缆vs现实"&#44;"gamePoints":""&#44;"gamePointsUrl":""&#44;"host":{"nick":"Noahzark"&#44;"uin":28696786}&#44;"icon":"http://miniapp.gtimg.cn/public/appicon/432b76be3a548fc128acaa6c1ec90131_200.jpg"&#44;"preview":"https://pic.ugcimg.cn/07cc5adddb5e6ef3cc27326a12b2df17/jpg1"&#44;"qqdocurl":"https://b23.tv/******"&#44;"scene":1036&#44;"shareTemplateData":{}&#44;"shareTemplateId":"8C8E89B49BE609866298ADDFF2DBABA4"&#44;"showLittleTail":""&#44;"title":"哔哩哔哩"&#44;"url":"m.q.qq.com/a/s/f6362a996fd107b3d4dbedce09c17d92"}}&#44;"prompt":"&#91;QQ小程序&#93;哔哩哔哩"&#44;"ver":"1.0.1.42"&#44;"view":"view_8C8E89B49BE609866298ADDFF2DBABA4"}]
```