### PR TITLE
chat_history部分字段调整为可null

### DIFF
--- a/models/chat_history.py
+++ b/models/chat_history.py
@@ -13,11 +13,11 @@ class ChatHistory(Model):
     """自增id"""
     user_qq = fields.BigIntField()
     """用户id"""
-    group_id = fields.BigIntField(null = True)
+    group_id = fields.BigIntField(null=True)
     """群聊id"""
-    text = fields.TextField(null = True)
+    text = fields.TextField(null=True)
     """文本内容"""
-    plain_text = fields.TextField(null = True)
+    plain_text = fields.TextField(null=True)
     """纯文本"""
     create_time = fields.DatetimeField(auto_now_add=True)
     """创建时间"""

--- a/models/chat_history.py
+++ b/models/chat_history.py
@@ -13,11 +13,11 @@ class ChatHistory(Model):
     """自增id"""
     user_qq = fields.BigIntField()
     """用户id"""
-    group_id = fields.BigIntField()
+    group_id = fields.BigIntField(null = True)
     """群聊id"""
-    text = fields.TextField()
+    text = fields.TextField(null = True)
     """文本内容"""
-    plain_text = fields.TextField()
+    plain_text = fields.TextField(null = True)
     """纯文本"""
     create_time = fields.DatetimeField(auto_now_add=True)
     """创建时间"""


### PR DESCRIPTION
字段group_id、text、plain_text修改为可空
使新建表结构与旧版基本一致
并且修复以下报错
CMD[定时任务] 定时批量添加聊天记录 || 错误 <class 'ValueError'>: group_id is non nullable field, but null was passed