### PR TITLE
把Config的type字段默认类型由str改为None

### DIFF
--- a/basic_plugins/init_plugin_config/init_plugin_info.py
+++ b/basic_plugins/init_plugin_config/init_plugin_info.py
@@ -117,7 +117,7 @@ def init_plugin_info():
                                     config.get("value"),
                                     help_=config.get("help"),
                                     default_value=config.get("default_value"),
-                                    type=config.get("type") or str,
+                                    type=config.get("type"),
                                 )
                         plugin_configs = plugin_cfg.configs
                     plugin_status = plugins_manager.get(plugin_model)

--- a/basic_plugins/init_plugin_config/init_plugins_config.py
+++ b/basic_plugins/init_plugin_config/init_plugins_config.py
@@ -50,7 +50,7 @@ def init_plugins_config():
                                 help_=plugin_configs[key].get("help"),
                                 default_value=plugin_configs[key].get("default_value"),
                                 _override=True,
-                                type=plugin_configs[key].get("type") or str,
+                                type=plugin_configs[key].get("type"),
                             )
                         else:
                             config = plugin_configs[key]
@@ -62,7 +62,7 @@ def init_plugins_config():
                                 help_=config.help,
                                 default_value=config.default_value,
                                 _override=True,
-                                type=config.type or str,
+                                type=config.type,
                             )
                 elif plugin_configs := _data.get(matcher.plugin_name):
                     for key in plugin_configs.configs:

--- a/configs/utils/__init__.py
+++ b/configs/utils/__init__.py
@@ -84,7 +84,7 @@ class ConfigsManager:
         name: Optional[str] = None,
         help_: Optional[str] = None,
         default_value: Optional[Any] = None,
-        type: Optional[Type] = str,
+        type: Optional[Type] = None,
         arg_parser: Optional[Callable] = None,
         _override: bool = False,
     ):


### PR DESCRIPTION
https://github.com/HibiKier/zhenxun_bot/blob/6826c10a095ae96682781c35bc8dd21814c89a7b/configs/utils/__init__.py#L186-L188
看这几行应该是若config指定type才执行转换，反之直接返回值，那么应当就没有必要把Config的默认type全指定为str（会导致第三方老插件不兼容）