### PR TITLE
修复config.yaml中把False也当成None的问题

### DIFF
--- a/configs/utils/__init__.py
+++ b/configs/utils/__init__.py
@@ -200,7 +200,7 @@ class ConfigsManager:
                         e=e,
                     )
                     value = config.value or config.default_value
-        if not value:
+        if value is None:
             value = default
         logger.debug(
             f"获取配置 MODULE: [<u><y>{module}</y></u>] | KEY: [<u><y>{key}</y></u>] -> [<u><c>{value}</c></u>]"

--- a/plugins/open_cases/__init__.py
+++ b/plugins/open_cases/__init__.py
@@ -102,7 +102,7 @@ Config.add_plugin_config(
     True,
     help_="被动 每日开箱重置提醒 进群默认开关状态",
     default_value=True,
-    type=int,
+    type=bool,
 )
 
 


### PR DESCRIPTION
真寻不知道什么时候的commit后，config.yaml里面的false都消失了
因为把False也判断成了None，然后就被赋值了None