### PR TITLE
修复BuildImage类text居中类型bug；修复原神今日素材有时发不出图片的问题

### DIFF
--- a/plugins/genshin/material_remind/__init__.py
+++ b/plugins/genshin/material_remind/__init__.py
@@ -56,8 +56,12 @@ async def _(event: MessageEvent):
     if not (IMAGE_PATH / "genshin" / "material" / f"{file_name}.png").exists():
         await update_image()
     await material.send(
+        # Message(
+        #     image(f"{file_name}.png", "genshin/material")
+        #     + "\n※ 每日素材数据来源于米游社"
+        # )
         Message(
-            image(f"{file_name}.png", "genshin/material")
+            image(IMAGE_PATH / "genshin" / "material" / f"{file_name}.png")
             + "\n※ 每日素材数据来源于米游社"
         )
     )
@@ -83,7 +87,7 @@ async def update_image():
             os.mkdir(f"{IMAGE_PATH}/genshin/material")
         for file in os.listdir(f"{IMAGE_PATH}/genshin/material"):
             os.remove(f"{IMAGE_PATH}/genshin/material/{file}")
-        browser = await get_browser()
+        browser = get_browser()
         if not browser:
             logger.warning("获取 browser 失败，请部署至 linux 环境....")
             return False
@@ -102,16 +106,3 @@ async def update_image():
         if page:
             await page.close()
         return False
-
-
-# 获取背景高度以及修改最后一张图片的黑边
-def get_background_height(weapons_img: List[str]) -> int:
-    height = 0
-    for weapons in weapons_img:
-        height += BuildImage(0, 0, background=weapons).size[1]
-    last_weapon = BuildImage(0, 0, background=weapons_img[-1])
-    w, h = last_weapon.size
-    last_weapon.crop((0, 0, w, h - 10))
-    last_weapon.save(weapons_img[-1])
-
-    return height

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -452,7 +452,7 @@ class BuildImage:
         说明:
             在图片上添加文字
         参数:
-            :param pos: 文字位置(使用center_type后会失效)
+            :param pos: 文字位置(使用center_type中的center后会失效,使用by_width后x失效,使用by_height后y失效)
             :param text: 文字内容
             :param fill: 文字颜色
             :param center_type: 居中类型，可能的值 center: 完全居中，by_width: 水平居中，by_height: 垂直居中

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -452,7 +452,7 @@ class BuildImage:
         说明:
             在图片上添加文字
         参数:
-            :param pos: 文字位置
+            :param pos: 文字位置(使用center_type后会失效)
             :param text: 文字内容
             :param fill: 文字颜色
             :param center_type: 居中类型，可能的值 center: 完全居中，by_width: 水平居中，by_height: 垂直居中
@@ -465,7 +465,12 @@ class BuildImage:
                     "center_type must be 'center', 'by_width' or 'by_height'"
                 )
             w, h = self.w, self.h
-            ttf_w, ttf_h = self.getsize(text)
+            longgest_text = ''
+            sentence = text.split("\n")
+            for x in sentence:
+                longgest_text = x if len(x) > len(longgest_text) else longgest_text
+            ttf_w, ttf_h = self.getsize(longgest_text)
+            ttf_h = ttf_h * len(sentence)
             if center_type == "center":
                 w = int((w - ttf_w) / 2)
                 h = int((h - ttf_h) / 2)


### PR DESCRIPTION
### 修复BuildImage类text居中类型bug
**问题概括**：不应该对字符串对象`text`直接`self.getsize(text)`。因为含`\n`的字符串在展示（发送出去）后是会分行的，而这样直接`self.getsize(text)`获得的是总长度和高度。以致于`ttf_w`过长，`ttf_h`过短，最终导致居中类型根据此数据计算出的`w`、`h`错误。
**图片说明**：
![3b41dc367c2ce37](https://user-images.githubusercontent.com/105900675/224975993-8cc65318-578a-49f2-a21b-4aa52c22136b.jpg)
修改前，`w`过小（甚至为负），`h`过大，导致文字位置不合理（文字的右下部分在图片左下角）。
![-32d66432e5c20d67](https://user-images.githubusercontent.com/105900675/224976429-05669b75-0223-4146-980c-1c0ae40fc67d.jpg)
修改后，恢复正常。
**修改说明**：原代码是通过整张图片大小乘以某个百分比计算出的文字位置，并非真正居中。而居中功能出现bug，通过将文字大小分行（按`\n`划分）计算即可解决。
### 修复原神今日素材有时发不出图片的问题
**问题概括**：貌似只是Message的构造方式有问题，不过顺便精细了一下其它内容。