### PR TITLE
webui插件适配多CQ端接入

### DIFF
--- a/plugins/web_ui/api/group.py
+++ b/plugins/web_ui/api/group.py
@@ -5,6 +5,7 @@ from utils.utils import get_bot
 
 from ..auth import Depends, User, token_to_user
 from ..config import *
+from nonebot import get_bots
 
 
 @app.get("/webui/group")
@@ -14,10 +15,11 @@ async def _(user: User = Depends(token_to_user)) -> Result:
     """
     group_list_result = []
     group_info = {}
-    if bot := get_bot():
-        group_list = await bot.get_group_list()
-        for g in group_list:
-            group_info[g["group_id"]] = Group(**g)
+    if bots := get_bots():
+        for bot in bots.values():
+            group_list = await bot.get_group_list()
+            for g in group_list:
+                group_info[g["group_id"]] = Group(**g)
     group_data = group_manager.get_data()
     for group_id in group_data.group_manager:
         try:


### PR DESCRIPTION
修改后，如果多CQ接入了真寻，也能在web后台看到所有群了，未修改前只能随机看到某个bot所在的群。

根据当前环境，一个GO-CQHTTP不敢接入太多群，否则容易遭到冻结，所以考虑多个CQ接入一个真寻，而部分被动推送的插件都没这样的适配，在多CQ接入的情况下无法正常运行，希望作者可以考虑这个思路修改相关插件。

PS:我是HoshinoBot（nonebot1)看过来的，nonebot2的多CQ适配不要太方便