### PR TITLE
修复更新群组成员列表时一直【删除已退群用户】

### DIFF
--- a/basic_plugins/admin_bot_manage/_data_source.py
+++ b/basic_plugins/admin_bot_manage/_data_source.py
@@ -329,7 +329,7 @@ async def update_member_info(
                         user_info["user_id"],
                         user_info["group_id"],
                     )
-                _exist_member_list.append(int(user_info["user_id"]))
+                _exist_member_list.append(str(user_info["user_id"]))
                 continue
             join_time = datetime.strptime(
                 time.strftime(
@@ -347,7 +347,7 @@ async def update_member_info(
                     ),
                 },
             )
-            _exist_member_list.append(int(user_info["user_id"]))
+            _exist_member_list.append(str(user_info["user_id"]))
             logger.debug("更新成功", "更新成员信息", user_info["user_id"], user_info["group_id"])
         _del_member_list = list(
             set(_exist_member_list).difference(


### PR DESCRIPTION
修复更新群组成员列表时一直【删除已退群用户】
![I}MY)~ECV0@Q1F)EE$_UKQO](https://user-images.githubusercontent.com/62053271/233849180-acaecd13-9c36-438e-8ba5-1d469807a262.png)
