### PR TITLE
🐛 修复好感度满后签到失败

### DIFF
--- a/plugins/sign_in/utils.py
+++ b/plugins/sign_in/utils.py
@@ -148,7 +148,9 @@ def _generate_card(
     ratio = 1 - (next_impression - user.impression) / (
         next_impression - previous_impression
     )
-    bar.resize(w=int(bar.w * ratio) or 1, h=bar.h)
+    if next_impression == 0:
+        ratio = 0
+    bar.resize(w=int(bar.w * ratio) or bar.w, h=bar.h)
     bar_bk.paste(
         bar,
         alpha=True,


### PR DESCRIPTION
若好感度满后签到会提示“height and width must be > 0”错误，但群里其他人签到正常。
定位发现好感满时执行`get_level_and_next_impression`将返回0作为`next_impression`，随后
`ratio = 1 - (next_impression - user.impression) / (next_impression - previous_impression)`
会得到一个负的ratio比率，此时`bar.w * ratio`得到一个负数，而非代码中所期望的0。

示例：
假设用户好感度为114514，则`get_level_and_next_impression`的调用结果为：
`next_impression = 0 && previous_impression = 9999`，故
`(next_impression - user.impression) / (next_impression - previous_impression)` = `(9999 - 114514) / (0 - 9999)` = `10.4525`，故
`ratio` = `1 - 10.4525` = `-9.4525`，不等于0，从而
`w` = `int(bar.w * ratio)` = `-9 * bar.w`。
而bar.w是正数（220），所以进入`resize`函数时将使用负数`w`作为参数，从而触发“height and width must be > 0”异常。

修复方法：在计算后添加一次判断，若`next_impression`为0（好感满）则令`ratio`等于0。