### PR TITLE
添加 本地图库插件 防吞图特性

### DIFF
--- a/plugins/image_management/send_image/__init__.py
+++ b/plugins/image_management/send_image/__init__.py
@@ -12,7 +12,7 @@ from utils.message_builder import image
 from utils.utils import FreqLimiter, cn2py, get_message_text, is_number
 
 from .rule import rule
-from .anti import pixRandomChangeFile
+from .anti import pix_random_change_file
 
 __zx_plugin_name__ = "本地图库"
 __plugin_usage__ = f"""
@@ -76,7 +76,7 @@ async def _(event: MessageEvent):
     if int(index) > length - 1 or int(index) < 0:
         await send_img.finish(f"超过当前上下限！({length - 1})")
     abs_path = os.path.join(os.getcwd(), path / f"{index}.jpg")
-    pixRandomChangeFile(abs_path)
+    pix_random_change_file(abs_path)
     result = image(path / f"{index}.jpg")
     if result:
         logger.info(

--- a/plugins/image_management/send_image/__init__.py
+++ b/plugins/image_management/send_image/__init__.py
@@ -12,6 +12,7 @@ from utils.message_builder import image
 from utils.utils import FreqLimiter, cn2py, get_message_text, is_number
 
 from .rule import rule
+from .anti import pixRandomChangeFile
 
 __zx_plugin_name__ = "本地图库"
 __plugin_usage__ = f"""
@@ -74,6 +75,8 @@ async def _(event: MessageEvent):
         return
     if int(index) > length - 1 or int(index) < 0:
         await send_img.finish(f"超过当前上下限！({length - 1})")
+    abs_path = os.path.join(os.getcwd(), path / f"{index}.jpg")
+    pixRandomChangeFile(abs_path)
     result = image(path / f"{index}.jpg")
     if result:
         logger.info(

--- a/plugins/image_management/send_image/anti.py
+++ b/plugins/image_management/send_image/anti.py
@@ -5,7 +5,7 @@ import numpy as np
 from PIL import Image
 
 
-def pixRandomChange(img):
+def pix_random_change(img):
     # Image转cv2
     img = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
     img[0, 0, 0] = random.randint(0, 0xfffffff)
@@ -14,13 +14,10 @@ def pixRandomChange(img):
     return img
 
 
-def pixRandomChangeFile(path):
+def pix_random_change_file(path: str):
     # 注意：cv2.imread()不支持路径中文
     warnings.filterwarnings("ignore", category=Warning)
     img = cv2.imread(path)
     img[0, 0, 0] = random.randint(0, 0xfffffff)
     cv2.imwrite(path, img)
-    print('finish')
 
-
-pixRandomChangeFile('./0.jpg')

--- a/plugins/image_management/send_image/anti.py
+++ b/plugins/image_management/send_image/anti.py
@@ -1,0 +1,26 @@
+import cv2
+import random
+import warnings
+import numpy as np
+from PIL import Image
+
+
+def pixRandomChange(img):
+    # Image转cv2
+    img = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+    img[0, 0, 0] = random.randint(0, 0xfffffff)
+    # cv2转Image
+    img = Image.fromarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+    return img
+
+
+def pixRandomChangeFile(path):
+    # 注意：cv2.imread()不支持路径中文
+    warnings.filterwarnings("ignore", category=Warning)
+    img = cv2.imread(path)
+    img[0, 0, 0] = random.randint(0, 0xfffffff)
+    cv2.imwrite(path, img)
+    print('finish')
+
+
+pixRandomChangeFile('./0.jpg')


### PR DESCRIPTION
经过多次测试发现，QQ吞图主要是判断图像哈希值，只要在图像发送前对某一个像素点修改即可避免被吞
已测试过在图片数据尾添加字节无法改变QQ发送图片后的哈希值，疑似QQ在图像发送前对其压缩过
![image](https://github.com/HibiKier/zhenxun_bot/assets/41728500/21c53029-7121-4505-9317-7d8a21bad694)
