### PR TITLE
修正ba抽卡资源下载地址

### DIFF
--- a/plugins/draw_card/handles/ba_handle.py
+++ b/plugins/draw_card/handles/ba_handle.py
@@ -113,7 +113,7 @@ class BaHandle(BaseHandle[BaChar]):
 
     async def _update_info(self):
         info = {}
-        url = "https://lonqie.github.io/SchaleDB/data/cn/students.min.json?v=49"
+        url = "https://schale.gg/data/cn/students.min.json?v=49"
         result = (await AsyncHttpx.get(url)).json()
         if not result:
             logger.warning(f"更新 {self.game_name_cn} 出错")
@@ -122,10 +122,11 @@ class BaHandle(BaseHandle[BaChar]):
             for char in result:
                 try:
                     name = char["Name"]
+                    id = str(char["Id"])
                     avatar = (
-                        "https://github.com/lonqie/SchaleDB/raw/main/images/student/icon/"
-                        + char["CollectionTexture"]
-                        + ".png"
+                        "https://github.com/SchaleDB/SchaleDB/raw/main/images/student/icon/"
+                        + id
+                        + ".webp"
                     )
                     star = char["StarGrade"]
                 except IndexError:


### PR DESCRIPTION
为防止代理缓存机制造成下载图像缺失，所以直接指向github而非其他代理