### PR TITLE
:bug: 为 'get_browser()' 添加缺少的 'await' 关键字

### DIFF
--- a/zhenxun/utils/http_utils.py
+++ b/zhenxun/utils/http_utils.py
@@ -305,7 +305,7 @@ class AsyncPlaywright:
         参数:
             user_agent: 请求头
         """
-        browser = get_browser()
+        browser = await get_browser()
         ctx = await browser.new_context(**kwargs)
         page = await ctx.new_page()
         try:


### PR DESCRIPTION
修复因未等待异步函数 `get_browser()` 导致未获取到浏览器实例进而引发的下游插件异常