### PR TITLE
 🐛 修复使用本地数据库中的色图时返回的数量不正确

### DIFF
--- a/zhenxun/plugins/send_setu_/send_setu/_data_source.py
+++ b/zhenxun/plugins/send_setu_/send_setu/_data_source.py
@@ -99,6 +99,7 @@ class SetuManage:
         if num > len(data_list):
             num = len(data_list)
             flag = True
+        data_list = random.sample(data_list, num)
         for setu in data_list:
             file = await cls.get_image(setu)
             if isinstance(file, str):


### PR DESCRIPTION
# 描述

本 pull request 在成功获取色图列表后对其进行再次采样，从而修复了返回超出数量色图的问题

# 分析

使用色图功能时注意到，在某些情况下 bot 会不受控制连续发出超出限制数量的色图

经调试发现如下段代码
https://github.com/HibiKier/zhenxun_bot/blob/4d6013ca02a80cce3961adbb3397a49f14ecfda5/zhenxun/plugins/send_setu_/send_setu/_data_source.py#L90-L96

当 LoliconAPI 无法获取结果时，程序转而使用本地数据库中的缓存代替

https://github.com/HibiKier/zhenxun_bot/blob/4d6013ca02a80cce3961adbb3397a49f14ecfda5/zhenxun/plugins/send_setu_/send_setu/_data_source.py#L138-L168

https://github.com/HibiKier/zhenxun_bot/blob/4d6013ca02a80cce3961adbb3397a49f14ecfda5/zhenxun/plugins/send_setu_/_model.py#L35-L42

然而，`get_setu_list` 函数在调用 `query_image` 函数时，未按照预期传入 `limit` 参数，从而导致 `get_setu_list` 函数可能返回最高可达 50 张的色图列表

而在第一段代码后续，并未对返回的 `data_list` 列表进行处理，导致了意外返回预期外数量的色图列表，使得 bot 发出超出预期数量的色图

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the bug causing the bot to return more images than requested by resampling the image list from the local database to ensure the correct number of images is returned.

Bug Fixes:
- Fix the issue where the bot returns more images than expected by resampling the list of images from the local database to match the requested number.

<!-- Generated by sourcery-ai[bot]: end summary -->