### PR TITLE
🎈 优先使用github api

### DIFF
--- a/zhenxun/utils/github_utils/__init__.py
+++ b/zhenxun/utils/github_utils/__init__.py
@@ -20,4 +20,4 @@ def parse_github_url(github_url: str) -> "RepoInfo":
 jsdelivr_api = RepoAPI(JsdelivrStrategy())  # type: ignore
 github_api = RepoAPI(GitHubStrategy())  # type: ignore
 
-api_strategy = [jsdelivr_api, github_api]
+api_strategy = [github_api, jsdelivr_api]


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

通过更改API策略优先顺序，优先使用GitHub API而不是jsDelivr API。

增强功能：
- 更改API策略优先顺序，以优先使用GitHub API而不是jsDelivr API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize the use of GitHub API over jsDelivr API by changing the order of API strategy preference.

Enhancements:
- Change the order of API strategy preference to prioritize GitHub API over jsDelivr API.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->