### PR TITLE
:bug: fix(http_utils): 流式下载Content-Length错误

### DIFF
--- a/__version__
+++ b/__version__
@@ -1,1 +1,1 @@
-__version__: v0.2.2-f9c7360
+__version__: v0.2.2-d539b1f

--- a/zhenxun/utils/http_utils.py
+++ b/zhenxun/utils/http_utils.py
@@ -286,7 +286,9 @@ class AsyncHttpx:
                                         f"Path: {path.absolute()}"
                                     )
                                     async with aiofiles.open(path, "wb") as wf:
-                                        total = int(response.headers["Content-Length"])
+                                        total = int(
+                                            response.headers.get("Content-Length", 0)
+                                        )
                                         with rich.progress.Progress(  # type: ignore
                                             rich.progress.TextColumn(path.name),  # type: ignore
                                             "[progress.percentage]{task.percentage:>3.0f}%",  # type: ignore
@@ -295,7 +297,8 @@ class AsyncHttpx:
                                             rich.progress.TransferSpeedColumn(),  # type: ignore
                                         ) as progress:
                                             download_task = progress.add_task(
-                                                "Download", total=total
+                                                "Download",
+                                                total=total if total else None,
                                             )
                                             async for chunk in response.aiter_bytes():
                                                 await wf.write(chunk)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

修复 `download_file` 函数以处理缺少 'Content-Length' 头的情况，默认值为零，确保下载过程不会失败。

错误修复：
- 修复 `download_file` 函数中 'Content-Length' 头的处理，以防止在头缺失时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the download_file function to handle cases where the 'Content-Length' header is missing by defaulting to zero, ensuring the download process does not fail.

Bug Fixes:
- Fix the handling of the 'Content-Length' header in the download_file function to prevent errors when the header is missing.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->