### PR TITLE
🐳 chore(update_version): 支持选择性的更新版本

### DIFF
--- a/.github/workflows/update_version_pr.yml
+++ b/.github/workflows/update_version_pr.yml
@@ -69,5 +69,5 @@ jobs:
           commit-message: ":tada: chore(version): Update version to ${{ steps.update_version.outputs.new_version }}"
           add-paths: __version__
           author: "AkashiCoin <i@loli.vet>"
-          committer: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"
           labels: automated-update

--- a/.github/workflows/update_version_pr.yml
+++ b/.github/workflows/update_version_pr.yml
@@ -1,14 +1,12 @@
 name: Update Version
 
 on:
-  pull_request_target:
+  push:
     paths:
+      - .github/workflows/update_version_pr.yml
       - zhenxun/**
       - resources/**
       - bot.py
-    types:
-      - opened
-      - synchronize
     branches:
       - main
       - dev
@@ -20,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Read current version
         id: read_version
@@ -46,20 +44,30 @@ jobs:
         run: echo "commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Update version file
+        id: update_version
         if: steps.check_diff.outputs.version_changed == 'false'
         run: |
           current_version="${{ steps.read_version.outputs.current_version }}"
           commit_hash="${{ steps.get_commit_hash.outputs.commit_hash }}"
           new_version="v${current_version}-${commit_hash}"
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "Updating version to: $new_version"
           echo "__version__: $new_version" > __version__
-          git config --global user.name "${{ github.event.pull_request.user.login }}"
-          git config --global user.email "${{ github.event.pull_request.user.login }}@users.noreply.github.com"
-          git add __version__
-          git remote set-url origin https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
-          git commit -m "chore(version): Update version to $new_version"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
 
       - name: Check updated version
         if: steps.check_diff.outputs.version_changed == 'false'
         run: cat __version__
+
+      - name: Create or update PR
+        if: steps.check_diff.outputs.version_changed == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          branch: create-pr/update_version
+          title: ":tada: chore(version): 自动更新版本到 ${{ steps.update_version.outputs.new_version }}"
+          body: "This PR updates the version file."
+          commit-message: ":tada: chore(version): Update version to ${{ steps.update_version.outputs.new_version }}"
+          add-paths: __version__
+          author: "AkashiCoin <i@loli.vet>"
+          committer: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          labels: automated-update


### PR DESCRIPTION
* 将版本更新变为pr，根据需要自主合并

## Summary by Sourcery

修改 CI 工作流程，以便在更改推送到特定路径和分支时，自动创建或更新版本更新的拉取请求。

CI:
- 将版本更新工作流程的触发器从 'pull_request_target' 更改为 'push'，适用于特定路径和分支。
- 添加一个步骤，当版本文件更新时，使用 'peter-evans/create-pull-request' 操作自动创建或更新拉取请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the CI workflow to automatically create or update a pull request for version updates when changes are pushed to specific paths and branches.

CI:
- Change the trigger for the version update workflow from 'pull_request_target' to 'push' for specific paths and branches.
- Add a step to create or update a pull request automatically when the version file is updated, using the 'peter-evans/create-pull-request' action.

</details>