### PR TITLE
fix: when user gold is negative, free plugins is also blocked

### DIFF
--- a/zhenxun/builtin_plugins/hooks/_auth_checker.py
+++ b/zhenxun/builtin_plugins/hooks/_auth_checker.py
@@ -501,7 +501,7 @@ class AuthChecker:
         返回:
             int: 需要消耗的金币
         """
-        if user.gold < plugin.cost_gold:
+        if user.gold < plugin.cost_gold and plugin.cost_gold > 0:
             """插件消耗金币不足"""
             try:
                 await MessageUtils.build_message(


### PR DESCRIPTION
某种情况下（历史数据迁移、主动扣除金币），当用户金币为负数时，即使是免费插件也无法使用

## Summary by Sourcery

错误修复：
- 修复了免费插件因用户金币余额为负而被阻止的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix issue where free plugins were blocked for users with negative gold balance.

</details>