### PR TITLE
🎈 perf(image_utils): 在image_utils中禁用代理下载

### DIFF
--- a/zhenxun/utils/image_utils.py
+++ b/zhenxun/utils/image_utils.py
@@ -402,7 +402,7 @@ async def get_download_image_hash(url: str, mark: str) -> str:
     """
     try:
         if await AsyncHttpx.download_file(
-            url, TEMP_PATH / f"compare_download_{mark}_img.jpg"
+            url, TEMP_PATH / f"compare_download_{mark}_img.jpg", use_proxy=False
         ):
             img_hash = get_img_hash(TEMP_PATH / f"compare_download_{mark}_img.jpg")
             return str(img_hash)

--- a/zhenxun/utils/image_utils.py
+++ b/zhenxun/utils/image_utils.py
@@ -390,7 +390,7 @@ def get_img_hash(image_file: str | Path) -> str:
     return str(hash_value)
 
 
-async def get_download_image_hash(url: str, mark: str) -> str:
+async def get_download_image_hash(url: str, mark: str, use_proxy: bool = False) -> str:
     """下载图片获取哈希值
 
     参数:
@@ -402,7 +402,7 @@ async def get_download_image_hash(url: str, mark: str) -> str:
     """
     try:
         if await AsyncHttpx.download_file(
-            url, TEMP_PATH / f"compare_download_{mark}_img.jpg", use_proxy=False
+            url, TEMP_PATH / f"compare_download_{mark}_img.jpg", use_proxy=use_proxy
         ):
             img_hash = get_img_hash(TEMP_PATH / f"compare_download_{mark}_img.jpg")
             return str(img_hash)


### PR DESCRIPTION
get_download_image_hash使用场景是访问腾讯服务器获取图片，无需走代理
由于get_download_image_hash函数主要是复读在使用，即使是走代理分流，在日志中还是会出现大量图片下载失败的报错，禁用代理后就不会出现这种问题

## Summary by Sourcery

错误修复：
- 禁用 `get_download_image_hash` 函数中的代理使用，以防止图像下载失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disable proxy usage in the get_download_image_hash function to prevent image download failures.

</details>