### PR TITLE
🐛 fix: 修复自定义pixiv反向代理无法对涩图生效

### DIFF
--- a/zhenxun/utils/utils.py
+++ b/zhenxun/utils/utils.py
@@ -189,6 +189,7 @@ def change_pixiv_image_links(
         url = (
             url.replace("i.pximg.net", nginx_url)
             .replace("i.pixiv.cat", nginx_url)
+            .replace("i.pixiv.re", nginx_url)
             .replace("_webp", "")
         )
     return url


### PR DESCRIPTION
修复bot涩图功能无法正确替换反代链接为自定义反代站。
lolicon API现在返回的url使用i.pixiv.re，change_pixiv_image_links()中没有预置对此的replace，添加对i.pixiv.re的replace以便自定义pixiv反代站可以正常工作于涩图🌟

## Summary by Sourcery

错误修复：
- 通过添加对替换 'i.pixiv.re' URL 的支持，修复了自定义 Pixiv 反向代理未应用于某些图像的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where custom Pixiv reverse proxy was not applied to certain images by adding support for replacing 'i.pixiv.re' URLs.

</details>