### PR TITLE
✨ 早晚安被动默认关闭

### DIFF
--- a/zhenxun/builtin_plugins/scheduler/morning.py
+++ b/zhenxun/builtin_plugins/scheduler/morning.py
@@ -20,7 +20,14 @@ __plugin_meta__ = PluginMetadata(
         author="HibiKier",
         version="0.1",
         plugin_type=PluginType.HIDDEN,
-        tasks=[Task(module="morning_goodnight", name="早晚安")],
+        tasks=[
+            Task(
+                module="morning_goodnight",
+                name="早晚安",
+                create_status=False,
+                default_status=False,
+            )
+        ],
     ).dict(),
 )
 


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 在调度器插件中将“早晚安”任务的默认状态设置为禁用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set the default status of the '早晚安' task to disabled in the scheduler plugin.

</details>