### PR TITLE
✨ 进群欢迎/退群提醒被动默认关闭

### DIFF
--- a/zhenxun/builtin_plugins/platform/qq/group_handle/__init__.py
+++ b/zhenxun/builtin_plugins/platform/qq/group_handle/__init__.py
@@ -71,8 +71,18 @@ __plugin_meta__ = PluginMetadata(
             ),
         ],
         tasks=[
-            Task(module="group_welcome", name="进群欢迎"),
-            Task(module="refund_group_remind", name="退群提醒"),
+            Task(
+                module="group_welcome",
+                name="进群欢迎",
+                create_status=False,
+                default_status=False,
+            ),
+            Task(
+                module="refund_group_remind",
+                name="退群提醒",
+                create_status=False,
+                default_status=False,
+            ),
         ],
     ).dict(),
 )


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 将 'group_welcome' 和 'refund_group_remind' 任务的默认状态设置为 false，使其默认处于非活动状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set the default status of 'group_welcome' and 'refund_group_remind' tasks to false, making them inactive by default.

</details>