### PR TITLE
✨ 插件配置新增is_show控制是否显示在菜单中

### DIFF
--- a/zhenxun/builtin_plugins/help/__init__.py
+++ b/zhenxun/builtin_plugins/help/__init__.py
@@ -29,6 +29,7 @@ __plugin_meta__ = PluginMetadata(
         author="HibiKier",
         version="0.1",
         plugin_type=PluginType.DEPENDANT,
+        is_show=False,
         configs=[
             RegisterConfig(
                 key="type",

--- a/zhenxun/builtin_plugins/help/_utils.py
+++ b/zhenxun/builtin_plugins/help/_utils.py
@@ -13,6 +13,7 @@ async def sort_type() -> dict[str, list[PluginInfo]]:
         menu_type__not="",
         load_status=True,
         plugin_type__in=[PluginType.NORMAL, PluginType.DEPENDANT],
+        is_show=True,
     )
     sort_data = {}
     for plugin in data:

--- a/zhenxun/builtin_plugins/init/init_plugin.py
+++ b/zhenxun/builtin_plugins/init/init_plugin.py
@@ -136,6 +136,7 @@ async def _():
                     "version",
                     "admin_level",
                     "plugin_type",
+                    "is_show",
                 ]
             )
             update_list.append(plugin)

--- a/zhenxun/configs/utils/__init__.py
+++ b/zhenxun/configs/utils/__init__.py
@@ -203,6 +203,8 @@ class PluginExtraData(BaseModel):
     """额外名称"""
     sql_list: list[str] | None = None
     """常用sql"""
+    is_show: bool = True
+    """是否显示在菜单中"""
 
 
 class NoSuchConfig(Exception):

--- a/zhenxun/models/plugin_info.py
+++ b/zhenxun/models/plugin_info.py
@@ -48,6 +48,8 @@ class PluginInfo(Model):
     """是否删除"""
     parent = fields.CharField(max_length=255, null=True, description="父插件")
     """父插件"""
+    is_show = fields.BooleanField(default=True, description="是否显示在帮助中")
+    """是否显示在帮助中"""
 
     class Meta:  # type: ignore
         table = "plugin_info"
@@ -81,4 +83,5 @@ class PluginInfo(Model):
     async def _run_script(cls):
         return [
             "ALTER TABLE plugin_info ADD COLUMN parent character varying(255);",
+            "ALTER TABLE plugin_info ADD COLUMN is_show boolean DEFAULT true;",
         ]


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 添加一个新的配置选项 'is_show'，用于控制插件在菜单中的可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a new configuration option 'is_show' to control the visibility of plugins in the menu.

</details>