### PR TITLE
新增戳一戳自检 

### DIFF
--- a/zhenxun/builtin_plugins/check/__init__.py
+++ b/zhenxun/builtin_plugins/check/__init__.py
@@ -1,14 +1,14 @@
+from nonebot import on_notice
+from nonebot.adapters.onebot.v11 import PokeNotifyEvent
 from nonebot.permission import SUPERUSER
 from nonebot.plugin import PluginMetadata
 from nonebot.rule import to_me
-from nonebot_plugin_alconna import Alconna, Arparma, on_alconna
+from nonebot_plugin_alconna import Alconna, on_alconna
 from nonebot_plugin_htmlrender import template_to_pic
-from nonebot_plugin_session import EventSession
-from nonebot import on_notice
-from nonebot.adapters.onebot.v11 import PokeNotifyEvent
 
+from zhenxun.configs.config import Config
 from zhenxun.configs.path_config import TEMPLATE_PATH
-from zhenxun.configs.utils import PluginExtraData
+from zhenxun.configs.utils import PluginExtraData, RegisterConfig
 from zhenxun.services.log import logger
 from zhenxun.utils.enum import PluginType
 from zhenxun.utils.message import MessageUtils
@@ -26,7 +26,17 @@ __plugin_meta__ = PluginMetadata(
         戳一戳BOT
     """.strip(),
     extra=PluginExtraData(
-        author="HibiKier", version="0.1", plugin_type=PluginType.SUPERUSER
+        author="HibiKier",
+        version="0.1",
+        plugin_type=PluginType.SUPERUSER,
+        configs=[
+            RegisterConfig(
+                key="type",
+                value="mix",
+                help="自检触发方式 ['message', 'poke', 'mix']",
+                default_value="mix",
+            )
+        ],
     ).dict(),
 )
 
@@ -51,19 +61,26 @@ async def handle_self_check():
         await MessageUtils.build_message(f"自检失败: {e}").send()
         logger.error("自检失败", e=e)
 
-#word
-_self_check_matcher = on_alconna(
-    Alconna("自检"), rule=to_me(), permission=SUPERUSER, block=True, priority=1
-)
 
-@_self_check_matcher.handle()
-async def _():
-    await handle_self_check()
+check_type = Config.get_config("check", "type")
 
-#poke
-_self_check_poke_matcher = on_notice(priority=5, block=False, rule=notice_rule(PokeNotifyEvent) & to_me())
+if check_type in {"message", "mix"}:
+    # message
+    _self_check_matcher = on_alconna(
+        Alconna("自检"), rule=to_me(), permission=SUPERUSER, block=True, priority=1
+    )
 
-@_self_check_poke_matcher.handle()
-async def _(event: PokeNotifyEvent):
-    await handle_self_check()
+    @_self_check_matcher.handle()
+    async def handle_message_check():
+        await handle_self_check()
 
+
+if check_type in {"poke", "mix"}:
+    # poke
+    _self_check_poke_matcher = on_notice(
+        priority=5, block=False, rule=notice_rule(PokeNotifyEvent) & to_me()
+    )
+
+    @_self_check_poke_matcher.handle()
+    async def handle_poke_check(event: PokeNotifyEvent):
+        await handle_self_check()

--- a/zhenxun/builtin_plugins/check/__init__.py
+++ b/zhenxun/builtin_plugins/check/__init__.py
@@ -61,7 +61,7 @@ async def _():
     await handle_self_check()
 
 #poke
-_self_check_poke_matcher = on_notice(priority=5, block=True, rule=notice_rule(PokeNotifyEvent) & to_me())
+_self_check_poke_matcher = on_notice(priority=5, block=False, rule=notice_rule(PokeNotifyEvent) & to_me())
 
 @_self_check_poke_matcher.handle()
 async def _(event: PokeNotifyEvent):


### PR DESCRIPTION
## Summary by Sourcery

添加一个新的自检触发方法“poke”，并重构自检功能以支持多种触发方法，包括“message”、“poke”和“mix”，增强了启动自检的灵活性。

新功能：
- 为机器人引入一个新的自检触发方法“poke”，允许用户通过戳机器人来启动自检。

增强功能：
- 重构自检功能以支持多种触发方法，包括“message”、“poke”和“mix”，增强了启动自检的灵活性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new self-check trigger method 'poke' and refactor the self-check functionality to support multiple trigger methods, including 'message', 'poke', and 'mix', enhancing flexibility in initiating self-checks.

New Features:
- Introduce a new self-check trigger method 'poke' for the bot, allowing users to initiate a self-check by poking the bot.

Enhancements:
- Refactor the self-check functionality to support multiple trigger methods, including 'message', 'poke', and 'mix', enhancing flexibility in how self-checks can be initiated.

</details>