### PR TITLE
fix(scheduler_admin): 修复定时任务列表页码显示逻辑

### DIFF
--- a/zhenxun/builtin_plugins/scheduler_admin/handlers.py
+++ b/zhenxun/builtin_plugins/scheduler_admin/handlers.py
@@ -78,7 +78,7 @@ async def handle_view(
     img = await presenters.format_schedule_list_as_image(
         schedules=schedules,
         title=title,
-        current_page=page.result if page.available else 1
+        current_page=page.result if page.available else 1,
     )
     await MessageUtils.build_message(img).send(reply_to=True)
 


### PR DESCRIPTION
- 在格式化定时任务列表图像时，添加对当前页码的可用性判断
- 如果页码不可用，则将当前页码默认设置为 1，避免显示错误的页码信息