### PR TITLE
fix: remove invalid shortcut anchor

### DIFF
--- a/zhenxun/builtin_plugins/admin/plugin_switch/command.py
+++ b/zhenxun/builtin_plugins/admin/plugin_switch/command.py
@@ -105,7 +105,7 @@ def _switch_wrapper(slot: str, content: str | None, context: dict) -> str:
 
 
 _status_matcher.shortcut(
-    r"^(?P<action>开启|关闭)\s*(?P<all>所有|全部)?\s*(?P<default>默认)?\s*(?P<type>群被动|被动|插件|功能)?\s*",
+    r"(?P<action>开启|关闭)\s*(?P<all>所有|全部)?\s*(?P<default>默认)?\s*(?P<type>群被动|被动|插件|功能)?\s*",
     command="switch {all} {default} {type} {action} {* }",
     wrapper=_switch_wrapper,  # type: ignore
     prefix=True,


### PR DESCRIPTION
## 问题背景
- `plugin_switch` 中有一个 `shortcut` key 以 `^` 开头
- `nonebot_plugin_alconna` 会因此发出警告：`Shortcut Key should not start with '^'`
- 该快捷命令同时设置了 `prefix=True`，与前导 `^` 的用法存在冲突

## 修改内容
- 移除该 `shortcut` 正则前导 `^`
- 保留原有匹配逻辑
- 保留 `prefix=True` 行为

## 影响范围
- 仅修改 `zhenxun/builtin_plugins/admin/plugin_switch/command.py`
- 属于单文件最小修复，不涉及其他命令行为调整

## 验证
- 执行 `python -m compileall zhenxun/builtin_plugins/admin/plugin_switch/command.py` 通过