### PR TITLE
feat: show ban info in request notices 在申请信息中显示永久黑名单提示

### DIFF
--- a/zhenxun/builtin_plugins/record_request.py
+++ b/zhenxun/builtin_plugins/record_request.py
@@ -15,6 +15,7 @@ from nonebot_plugin_session import EventSession
 
 from zhenxun.configs.config import BotConfig, Config
 from zhenxun.configs.utils import PluginExtraData, RegisterConfig
+from zhenxun.models.ban_console import BanConsole
 from zhenxun.models.event_log import EventLog
 from zhenxun.models.fg_request import FgRequest
 from zhenxun.models.friend_user import FriendUser
@@ -86,6 +87,44 @@ async def _safe_get_group_info(bot, group_id: str):
         return None
 
 
+def _format_ban_target(ban_data: BanConsole) -> str:
+    user_id = ban_data.user_id or ""
+    group_id = ban_data.group_id or ""
+    if user_id and group_id:
+        return f"用户 {user_id} 在群组 {group_id}"
+    if user_id:
+        return f"用户 {user_id}"
+    return f"群组 {group_id}"
+
+
+async def _build_permanent_ban_tip(
+    *targets: tuple[str | None, str | None],
+) -> str:
+    ban_list: list[BanConsole] = []
+    seen: set[tuple[str, str]] = set()
+    for user_id, group_id in targets:
+        ban_data = await BanConsole.get_ban(user_id=user_id, group_id=group_id)
+        if not ban_data or ban_data.duration != -1:
+            continue
+        key = (ban_data.user_id or "", ban_data.group_id or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        ban_list.append(ban_data)
+    if not ban_list:
+        return ""
+    lines = ["", "永久黑名单提示："]
+    for ban_data in ban_list:
+        lines.extend(
+            [
+                f"- {_format_ban_target(ban_data)} 在黑名单中",
+                f"  操作员ID：{ban_data.operator}",
+                f"  封禁原因：{ban_data.ban_reason or '无'}",
+            ]
+        )
+    return "\n".join(lines)
+
+
 @friend_req.handle()
 async def _(bot: v12Bot | v11Bot, event: FriendRequestEvent, session: EventSession):
     logger.debug("收录好友请求...", "好友请求", target=event.user_id)
@@ -124,6 +163,7 @@ async def _(bot: v12Bot | v11Bot, event: FriendRequestEvent, session: EventSessi
         cache_key = str(event.user_id)
         if not cache.get(cache_key):
             cache.set(cache_key, "1")
+            ban_tip = await _build_permanent_ban_tip((str(event.user_id), None))
             results = await PlatformUtils.send_superuser(
                 bot,
                 f"*****一份好友申请*****\n"
@@ -131,7 +171,8 @@ async def _(bot: v12Bot | v11Bot, event: FriendRequestEvent, session: EventSessi
                 f"昵称：{nickname}({event.user_id})\n"
                 f"自动同意：{'√' if base_config.get('AUTO_ADD_FRIEND') else '×'}\n"
                 f"日期：{datetime.now().replace(microsecond=0)}\n"
-                f"备注：{event.comment}",
+                f"备注：{event.comment}"
+                f"{ban_tip}",
             )
             if message_ids := [
                 str(r[1].msg_ids[0]["message_id"])
@@ -210,13 +251,19 @@ async def _(bot: v12Bot | v11Bot, event: GroupRequestEvent, session: EventSessio
                 group_id=str(event.group_id),
                 handle_type=RequestHandleType.APPROVE,
             )
+            ban_tip = await _build_permanent_ban_tip(
+                (str(event.user_id), None),
+                (str(event.user_id), str(event.group_id)),
+                (None, str(event.group_id)),
+            )
             results = await PlatformUtils.send_superuser(
                 bot,
                 f"*****一份入群申请*****\n"
                 f"ID：{f.id}\n"
                 f"申请人：{nickname}({event.user_id})\n群聊："
                 f"{event.group_id}\n邀请日期：{datetime.now().replace(microsecond=0)}\n"
-                "注: 该请求已自动同意",
+                "注: 该请求已自动同意"
+                f"{ban_tip}",
             )
             await asyncio.sleep(random.randint(1, 5))
             await bot.send_private_msg(
@@ -263,13 +310,19 @@ async def _(bot: v12Bot | v11Bot, event: GroupRequestEvent, session: EventSessio
             if kick_count
             else ""
         )
+        ban_tip = await _build_permanent_ban_tip(
+            (str(event.user_id), None),
+            (str(event.user_id), str(event.group_id)),
+            (None, str(event.group_id)),
+        )
         results = await PlatformUtils.send_superuser(
             bot,
             f"*****一份入群申请*****\n"
             f"ID：{f.id}\n"
             f"申请人：{nickname}({event.user_id})\n群聊："
             f"{event.group_id}\n邀请日期：{datetime.now().replace(microsecond=0)}"
-            f"{kick_message}",
+            f"{kick_message}"
+            f"{ban_tip}",
         )
         if message_ids := [
             str(r[1].msg_ids[0]["message_id"]) for r in results if r[1] and r[1].msg_ids


### PR DESCRIPTION
 变更内容
- 好友申请通知中增加永久黑名单提示
- 群组邀请通知中检查邀请者全局黑名单、邀请者在目标群的黑名单、目标群本身黑名单
- 命中永久封禁时，在申请信息中展示目标、操作员 ID 和封禁原因

解决问题
收到好友或群组申请时，管理员可以直接在申请通知中看到相关用户或群组是否处于永久黑名单，避免误通过已封禁对象。
Closes #2032
验证
- `python -m compileall zhenxun\builtin_plugins\record_request.py`
- `python -m ruff check zhenxun\builtin_plugins\record_request.py`
- `git diff --check`