### PR TITLE
fix(plugin_store): 移除安装插件时多余的目标路径参数传递

### DIFF
--- a/zhenxun/builtin_plugins/plugin_store/data_source.py
+++ b/zhenxun/builtin_plugins/plugin_store/data_source.py
@@ -370,8 +370,6 @@ class StoreManager:
             download_files,
             branch,
             repo_type=repo_type,
-            sparse_path=replace_module_path,
-            target_dir=target_dir,
         )
         if not result.success:
             raise PluginStoreException(result.error_message)


### PR DESCRIPTION
移除了 StoreManager 中 download_files 方法调用时的 sparse_path 和 target_dir 参数，这些参数不再需要。